### PR TITLE
Cleanup

### DIFF
--- a/src/traits.js
+++ b/src/traits.js
@@ -71,9 +71,7 @@ var Trait = (function(){
   var slice = bindThis(call, Array.prototype.slice);
     
   // feature testing such that traits.js runs on both ES3 and ES5
-  var forEach = Array.prototype.forEach ?
-      bindThis(call, Array.prototype.forEach) :
-      function(arr, fun) {
+  var forEach = function(arr, fun) {
         for (var i = 0, len = arr.length; i < len; i++) { fun(arr[i]); }
       };
   

--- a/src/traits.js
+++ b/src/traits.js
@@ -78,9 +78,6 @@ var Trait = (function(){
       };
   
   var freeze = Object.freeze || function(obj) { return obj; };
-  var getPrototypeOf = Object.getPrototypeOf || function(obj) { 
-    return Object.prototype;
-  };
   var getOwnPropertyNames = Object.getOwnPropertyNames ||
       function(obj) {
         var props = [];


### PR DESCRIPTION
Hi @tvcutsem 

I've scanned through the source and found an unused function, *getPrototypeOf*, and simplified the forEach polyfill. Since we only use the `forEach(item)` version, there is no need for the native `forEach(item, index, entireArray)` + scope/context stuff. Relying on the native version would break in ES3 anyway.

As per question #1, I'm trying to use `traits.js` with existing classes (es5 style though). Perhaps, I should open a new issue with my questions...