### PR TITLE
Fix prototype can be null in Object.create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traits.js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "traits.js is a minimal, standards-compliant trait composition library for Javascript.",
   "main": "dist/traits.js",
   "module": "src/traits.js",

--- a/src/traits.js
+++ b/src/traits.js
@@ -562,8 +562,9 @@ var Trait = (function(){
       var pd = trait[name];
       // check for remaining 'required' properties
       // Note: it's OK for the prototype to provide the properties
+      // Fixed: proto can be null: https://github.com/traitsjs/traits.js/issues/11
       if (pd.required) {
-        if (!(name in proto)) {
+        if (proto === null || !(name in proto)) {
           throw new Error('Missing required property: '+name);
         }
       } else if (pd.conflict) { // check for remaining conflicting properties

--- a/tests/traitstests.js
+++ b/tests/traitstests.js
@@ -595,8 +595,8 @@
     try {
       var o7 = Object.create(null,
                    Trait({ foo: Trait.required }));
-      assert.ok(('foo' in o4), 'required property present');
-      assert.ok(!(o4.foo), 'required property undefined');
+      assert.ok(('foo' in o7), 'required property present');
+      assert.ok(!(o7.foo), 'required property undefined');
     } catch(e) {
       assert.ok(false, 'did not expect create to complain about required props');
     }

--- a/tests/traitstests.js
+++ b/tests/traitstests.js
@@ -590,3 +590,14 @@
       assert.strictEqual( e.message, 'Remaining conflicting property: m', 'diamond prop conflict');
     }
   });
+
+  QUnit.test('can handle prototype being null', function(assert) {
+    try {
+      var o7 = Object.create(null,
+                   Trait({ foo: Trait.required }));
+      assert.ok(('foo' in o4), 'required property present');
+      assert.ok(!(o4.foo), 'required property undefined');
+    } catch(e) {
+      assert.ok(false, 'did not expect create to complain about required props');
+    }
+  });


### PR DESCRIPTION
If you use `Trait.create(null, trait)` or `Object.create(null, trait)` then traits.js will crash while examining `Trait.required` properties.

This PR fixes that.

Ref: #11 